### PR TITLE
Fix quarkus native ssl

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,6 +2,7 @@
 # key = value
 # mp.jwt.verify.publickey.location=${JWT_PUBLIC_KEY_URL}
 quarkus.swagger-ui.always-include=true
+quarkus.native.enable-https-url-handler=true
 
 quarkus.http.cors=true
 quarkus.smallrye-jwt.enabled=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,6 +3,7 @@
 # mp.jwt.verify.publickey.location=${JWT_PUBLIC_KEY_URL}
 quarkus.swagger-ui.always-include=true
 quarkus.native.enable-https-url-handler=true
+quarkus.ssl.native=true
 
 quarkus.http.cors=true
 quarkus.smallrye-jwt.enabled=true


### PR DESCRIPTION
Add the appropriate Quarkus config params for the native-image build to include the libraries required for the app to make calls to HTTPS endpoints.