### PR TITLE
auto-disable security  sso in dev mode. Add a fake config file for FE

### DIFF
--- a/src/main/resources/META-INF/resources/fake-config.json
+++ b/src/main/resources/META-INF/resources/fake-config.json
@@ -1,0 +1,7 @@
+{
+  "cloud-providers": [
+    { "name": "ETL", "description": "Labs Data Center" },
+    { "name": "AWS", "description": "Amazon" },
+    { "name": "GCP", "description": "Google" }
+  ]
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,15 +1,13 @@
-# Configuration file
-# key = value
-# mp.jwt.verify.publickey.location=${JWT_PUBLIC_KEY_URL}
 quarkus.swagger-ui.always-include=true
 quarkus.native.enable-https-url-handler=true
 quarkus.ssl.native=true
-
 quarkus.http.cors=true
 quarkus.smallrye-jwt.enabled=true
-
 resteasy.role.based.security=true
 
 quarkus.http.auth.policy.role-policy1.roles-allowed=manage_projects
 quarkus.http.auth.permission.roles1.paths=/project/secure
 quarkus.http.auth.permission.roles1.policy=role-policy1
+
+%dev.quarkus.smallrye-jwt.enabled=false
+%dev.resteasy.role.based.security=false


### PR DESCRIPTION
run a little bit differently in dev mode. Allows developer to go around security restrictions. There is also a json file example of config data.