### PR TITLE
Updated GIT API Path to used Engagements instead of Residencies

### DIFF
--- a/src/main/java/com/redhat/labs/omp/rest/client/OMPGitLabAPIService.java
+++ b/src/main/java/com/redhat/labs/omp/rest/client/OMPGitLabAPIService.java
@@ -17,7 +17,7 @@ public interface OMPGitLabAPIService {
     Response getFile(@QueryParam("name") String name, @QueryParam("repo_id") String repoId);
 
     @POST
-    @Path("/api/residencies")
+    @Path("/api/v1/engagements")
     @Produces("application/json")
     Response createEngagement(Engagement engagement);
 


### PR DESCRIPTION
The git api was changed in the following PR:
https://github.com/rht-labs/open-management-portal-git-api/pull/34

Changing the backend to call:
/api/v1/engagements
instead of:
/api/residencies

Should be able to close https://gitlab.consulting.redhat.com/rht-labs/labs-sre/documentation/issues/98 afterwards.
