### PR TITLE
Make MongoDB part of deployment

### DIFF
--- a/deployment/templates/mongodb-deploymentconfig.yaml
+++ b/deployment/templates/mongodb-deploymentconfig.yaml
@@ -1,0 +1,98 @@
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  labels:
+    app: {{ .Values.name }}
+  name: "{{ .Values.name }}-mongodb"
+spec:
+  replicas: 1
+  selector:
+    app: "{{ .Values.name }}-mongodb"
+    deploymentconfig: "{{ .Values.name }}-mongodb"
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: "{{ .Values.name }}-mongodb"
+        deploymentconfig: "{{ .Values.name }}-mongodb"
+    spec:
+      containers:
+      - capabilities: {}
+        env:
+        - name: MONGODB_USER
+          valueFrom:
+            secretKeyRef:
+              key: MONGODB_USER
+              name: "{{ .Values.name }}-configuration"
+        - name: MONGODB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: MONGODB_PASSWORD
+              name: "{{ .Values.name }}-configuration"
+        - name: MONGODB_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: MONGODB_ADMIN_PASSWORD
+              name: "{{ .Values.name }}-configuration"
+        - name: MONGODB_DATABASE
+          valueFrom:
+            secretKeyRef:
+              key: MONGODB_DATABASE
+              name: "{{ .Values.name }}-configuration"
+        image: ' '
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          initialDelaySeconds: 30
+          tcpSocket:
+            port: 27017
+          timeoutSeconds: 1
+        name: mongodb
+        ports:
+        - containerPort: 27017
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -i
+            - -c
+            - mongo 127.0.0.1:27017/$MONGODB_DATABASE -u $MONGODB_USER -p $MONGODB_PASSWORD
+              --eval="quit()"
+          initialDelaySeconds: 3
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 512Mi
+      securityContext:
+        capabilities: {}
+        privileged: false
+      terminationMessagePath: /dev/termination-log
+      volumeMounts:
+      - mountPath: /var/lib/mongodb/data
+        name: "{{ .Values.name }}-data"
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      volumes:
+      {{- if .Values.mongodb.persistent }}
+      - name: "{{ .Values.name }}-data"
+        persistentVolumeClaim:
+          claimName: "{{ .Values.name }}-mongodb"
+      {{- else }}
+      - emptyDir:
+          medium: ""
+        name: "{{ .Values.name }}-data"
+      {{- end }}
+  triggers:
+  - imageChangeParams:
+      automatic: true
+      containerNames:
+      - mongodb
+      from:
+        kind: ImageStreamTag
+        name: mongodb:{{ .Values.mongodb.version | default "3.6" }}
+        namespace: openshift
+      lastTriggeredImage: ""
+    type: ImageChange
+  - type: ConfigChange
+status: {}

--- a/deployment/templates/mongodb-pvc.yaml
+++ b/deployment/templates/mongodb-pvc.yaml
@@ -1,0 +1,13 @@
+---
+{{- if .Values.mongodb.persistent }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "{{ .Values.name }}-mongodb"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+{{- end }}

--- a/deployment/templates/mongodb-service.yaml
+++ b/deployment/templates/mongodb-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ .Values.name }}
+  name: "{{ .Values.name }}-mongodb"
+spec:
+  ports:
+  - name: mongo
+    nodePort: 0
+    port: 27017
+    protocol: TCP
+    targetPort: 27017
+  selector:
+    app: "{{ .Values.name }}-mongodb"
+    deploymentconfig: "{{ .Values.name }}-mongodb"
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}
+

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -4,3 +4,7 @@ servicePort: 8080
 
 imageName: "quay.io/rht-labs/omp-backend"
 imageTag: "latest" # This is intended to be overridden by the parent Helm chart.
+
+mongodb:
+  persistent: true
+  version: 3.6


### PR DESCRIPTION
This will complete [#185](https://gitlab.consulting.redhat.com/rht-labs/labs-sre/documentation/-/issues/185).
The `omp-backend-configuration` secret will come from the runtime-config