### PR TITLE
Sync to Git API Error Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ This project was built using Quarkus.
 
 ## Testing
 
-This project runs unit tests using an alternate application profile, which disables JWT token verification and user role verification. This means that all endpoints are available without returning 401 or 403, but the user context is not available during tests.
+This project runs tests using an embedded Mongo DB and Using the TokenUtils found in the test directory.  The only component Mocked is the external REST Client calls to the Git API.
 
 ## Useful Commands
 
@@ -135,3 +135,4 @@ mvn test
 # build for production
 mvn quarkus:build
 ```
+

--- a/README.md
+++ b/README.md
@@ -57,22 +57,61 @@ A configurable auto sync feature allows data that has been modified in Mongo DB 
 auto.save.cron.expr=0/30 * * * * ?
 ```
 
+__NOTE:__ There is no current auto sync from Gitlab to Mongo DB.  The `/engagements/refresh` API can be used to force a refresh of the data in Mongo DB from Gitlab if changes have been made without using the Backend APIs
+
 ## Configuration
 
 The following environment variables are available:
+
+### Logging
+| Name | Example Value | Required |
+|------|---------------|----------|
+| JWT_LOGGING| INFO | False |
+| OMP_BACKEND_LOGGING | INFO | False |
+
+### JWT
 
 | Name | Example Value | Required |
 |------|---------------|----------|
 | JWT_PUBKICKEY_LOCATION | http://[your-cluster-internal-sso-service-name]:8080/auth/realms/[your-realm-id]/protocol/openid-connect/certs | True |
 | JWT_ISSUER | http://[your-cluster-internal-sso-service-name] | True |
 | JWT_ENABLE | True | False |
+
+### Mongo DB
+
+| Name | Example Value | Required |
+|------|---------------|----------|
 | MONGODB_USER | monguser | True |
 | MONGODB_PASSWORD | mongopassword | True |
 | DATABASE_SERVICE_NAME | omp-backend-mongodb | True |
 | MONGODB_DATABASE | engagements | True |
+
+### Config Resource
+
+| Name | Example Value | Required |
+|------|---------------|----------|
 | CONFIG_REPOSITORY_ID |  1234             |  True        |
-| CONFIG_REPOSITORY_PATH | schema/config.yml | True |
+| CONFIG_FILE | schema/config.yml | False |
+
+### Git API
+
+| Name | Example Value | Required |
+|------|---------------|----------|
 | OMP_GITLAB_API_URL   | http://omp-git-api:8080 | True |
+
+### Version Resource
+
+| Name | Example Value | Required |
+|------|---------------|----------|
+| OMP_BACKEND_GIT_COMMIT | not.set | False |
+| OMP_BACKEND_GIT_TAG | not.set | False |
+| OMP_BACKEND_VERSIONS_PATH | /config/version-manifest.yml | False |
+
+### Git Auto Sync
+
+| Name | Example Value | Required |
+|------|---------------|----------|
+| AUTO_SAVE_CRON_EXPR | 0/30 * * * * ? | False |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,13 @@ The API for the Open Management Portal.
 ## JSON REST APIs
 
 The JSON REST APIs consist of three resources types:
+
 * config
 * engagements
 * git sync
 * version
+
+The application, once running, also exposes a Swagger UI that will provide more details about each of the APIs described below.  It can be found using the `/swagger-ui` path for the application.
 
 ### Config Resource
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,60 @@
 
 # Open Management Portal - Backend
 
-> The API for the Open Management Portal.
+The API for the Open Management Portal.
+
+## JSON REST APIs
+
+The JSON REST APIs consist of three resources types:
+* config
+* engagements
+* git sync
+* version
+
+### Config Resource
+
+The config resource exposes an API that will return the configured config file from git using the Git API.
+
+```
+GET /config
+```
+
+### Engagement Resource
+
+The engagements resource exposes an API that allows clients to create, retrieve, and delete engagement resources.  The unique key for an engagement consists of `customer_name` and `project_name`.  The following endpoints will update the configured Mongo DB and mark the records as modified so an asynchronous process can push the changes to Gitlab using the Git API.
+
+```
+# create an engagement
+POST /engagements
+# update a specific engagement
+PUT  /engagements/customers/{customerId}/projects/{projectId}
+# adds launch data to an engagement and syncs with git api
+PUT  /engagements/launch
+# retrieve all engagements
+GET  /engagements
+# retrieve a specific engagement
+GET  /engagements/customers/{customerId}/projects/{projectId}
+```
+
+### Git Sync Resource
+
+There are two exposed endpoints that will allow clients to deliberately sync data from Mongo DB to Gitlab using the Git API or to clear the data from the Mongo DB and insert all engagements from Gitlab.
+
+```
+# push all modified resources from Mongo DB to Gitlab
+PUT  /engagements/process/modified
+# clear Mongo DB, replace with engagement data from Gitlab
+PUT  /engagements/refresh
+```
+
+## Scheduled Auto Sync to Git API
+
+A configurable auto sync feature allows data that has been modified in Mongo DB to be pushed to Gitlab using the Git API.  This feature is configured using a CRON expression that can be updated in the application.properties file or overridden using environment variables.
+
+```
+# defaults to sync every 30 seconds
+auto.save.cron.expr=0/30 * * * * ?
+```
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The application, once running, also exposes a Swagger UI that will provide more 
 
 ### Config Resource
 
-The config resource exposes an API that will return the configured config file from git using the Git API.
+The config resource exposes an API that will return the configured config file from git using the [Git API](https://github.com/rht-labs/open-management-portal-git-api).
 
 ```
 GET /config
@@ -25,7 +25,7 @@ GET /config
 
 ### Engagement Resource
 
-The engagements resource exposes an API that allows clients to create, retrieve, and delete engagement resources.  The unique key for an engagement consists of `customer_name` and `project_name`.  The following endpoints will update the configured Mongo DB and mark the records as modified so an asynchronous process can push the changes to Gitlab using the Git API.
+The engagements resource exposes an API that allows clients to create, retrieve, and delete engagement resources.  The unique key for an engagement consists of `customer_name` and `project_name`.  The following endpoints will update the configured Mongo DB and mark the records as modified so an asynchronous process can push the changes to Gitlab using the [Git API](https://github.com/rht-labs/open-management-portal-git-api).
 
 ```
 # create an engagement
@@ -42,7 +42,7 @@ GET  /engagements/customers/{customerId}/projects/{projectId}
 
 ### Git Sync Resource
 
-There are two exposed endpoints that will allow clients to deliberately sync data from Mongo DB to Gitlab using the Git API or to clear the data from the Mongo DB and insert all engagements from Gitlab.
+There are two exposed endpoints that will allow clients to deliberately sync data from Mongo DB to Gitlab using the [Git API](https://github.com/rht-labs/open-management-portal-git-api) or to clear the data from the Mongo DB and insert all engagements from Gitlab.
 
 ```
 # push all modified resources from Mongo DB to Gitlab
@@ -61,7 +61,7 @@ GET  /api/v1/version
 
 ## Scheduled Auto Sync to Git API
 
-A configurable auto sync feature allows data that has been modified in Mongo DB to be pushed to Gitlab using the Git API.  This feature is configured using a CRON expression that can be updated in the application.properties file or overridden using environment variables.
+A configurable auto sync feature allows data that has been modified in Mongo DB to be pushed to Gitlab using the [Git API](https://github.com/rht-labs/open-management-portal-git-api).  This feature is configured using a CRON expression that can be updated in the application.properties file or overridden using environment variables.
 
 ```
 # defaults to sync every 30 seconds

--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ PUT  /engagements/process/modified
 PUT  /engagements/refresh
 ```
 
+### Version Resource
+
+The version resource exposes an endpoint that will allow the client to determine which versions of the backend, git api, and other components being used by OMP.
+
+```
+GET  /api/v1/version
+```
+
 ## Scheduled Auto Sync to Git API
 
 A configurable auto sync feature allows data that has been modified in Mongo DB to be pushed to Gitlab using the Git API.  This feature is configured using a CRON expression that can be updated in the application.properties file or overridden using environment variables.

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -44,7 +44,7 @@ quarkus.mongodb.database=${MONGODB_DATABASE:engagement}
 quarkus.mongodb.connection-string=mongodb://${mongo.user}:${mongo.password}@${mongo.service.name}/${quarkus.mongodb.database}
 
 #default values are dummy
-configFileCacheKey=${CONFIG_REPOSITORY_PATH:schema/config.yml}
+configFile=${CONFIG_FILE:schema/config.yml}
 configRepositoryId=${CONFIG_REPOSITORY_ID:9407}
 omp.gitlab.api/mp-rest/url=${OMP_GITLAB_API_URL:http://omp-git-api:8080}
 

--- a/src/test/java/com/redhat/labs/omp/rest/client/MockOMPGitLabAPIService.java
+++ b/src/test/java/com/redhat/labs/omp/rest/client/MockOMPGitLabAPIService.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
 import org.eclipse.microprofile.rest.client.inject.RestClient;
@@ -46,7 +47,7 @@ public class MockOMPGitLabAPIService implements OMPGitLabAPIService {
 
         } else if (SCENARIO.RUNTIME_EXCEPTION.value.equalsIgnoreCase(engagement.getDescription())) {
 
-            return Response.serverError().build();
+            throw new WebApplicationException("uh oh");
 
         } else if (SCENARIO.SERVER_ERROR.value.equalsIgnoreCase(engagement.getDescription())) {
 


### PR DESCRIPTION
Issue:

When the process method is called from either the endpoint or the auto sync feature, if a REST call to the `/engagements` endpoint  returns a 400 or greater response code, a WebApplicationException is thrown.  This results in the method returning without processing any other modified engagements.

Fix:

Now catching the WebApplicationException and logging the error, the engagement, and a note saying that a refresh of data may be necessary from Git.  After logging, any other modified engagements will be processed.  Any engagements that failed to be pushed to Git API and GitLab will be tried again on the next invocation of the process method.  

Monitoring of the logged exceptions should be conducted so that we can determine if a refresh is required.

Also, incorporated and closed #52 which are just README updates.