### PR TITLE
Use New Roles to Secure Endpoints

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,16 +22,21 @@ mp.jwt.verify.issuer=${JWT_ISSUER:https://quarkus.io/using-jwt-rbac}
 quarkus.smallrye-jwt.enabled=${JWT_ENABLE:true}
 
 # define auth roles
-quarkus.http.auth.policy.role-reader.roles-allowed=manage_projects
-quarkus.http.auth.policy.role-writer.roles-allowed=manage_projects
+quarkus.http.auth.policy.role-reader.roles-allowed=reader,writer
+quarkus.http.auth.policy.role-writer.roles-allowed=writer
 
 # set the /config endpoint(s) to reader or admin role
 quarkus.http.auth.permission.read.paths=/config
 quarkus.http.auth.permission.read.policy=role-reader
 
-# set the /engagements endpoint(s) to writer or admin role
-quarkus.http.auth.permission.writer.paths=/engagements
+# set the /engagements/* endpoint(s) to writer for PUT and POST methods
+quarkus.http.auth.permission.writer.paths=/engagements/*
 quarkus.http.auth.permission.writer.policy=role-writer
+quarkus.http.auth.permission.writer.methods=PUT,POST
+
+# set the /engagements/* endpoint(s) to reader for other methods
+quarkus.http.auth.permission.reader.paths=/engagements/*
+quarkus.http.auth.permission.reader.policy=role-reader
 
 quarkus.package.uber-jar=true
 

--- a/src/test/java/com/redhat/labs/omp/resources/ConfigResourceTest.java
+++ b/src/test/java/com/redhat/labs/omp/resources/ConfigResourceTest.java
@@ -38,7 +38,7 @@ public class ConfigResourceTest {
 	public void testGetConfigTokenHasWrongRole() throws Exception {
 
         HashMap<String, Long> timeClaims = new HashMap<>();
-        String token = TokenUtils.generateTokenString("/JwtClaimsWriter.json", timeClaims);
+        String token = TokenUtils.generateTokenString("/JwtClaimsUnknown.json", timeClaims);
 
 		given()
 			.when()

--- a/src/test/resources/JwtClaimsUnknown.json
+++ b/src/test/resources/JwtClaimsUnknown.json
@@ -1,0 +1,16 @@
+{
+    "iss": "https://quarkus.io/using-jwt-rbac",
+    "jti": "a-123",
+    "sub": "jdoe-using-jwt-rbac",
+    "upn": "jdoe@quarkus.io",
+    "preferred_username": "jdoe",
+    "aud": "using-jwt-rbac",
+    "birthdate": "2001-07-13",
+    "roleMappings": {
+        "group1": "Group1MappedRole",
+        "group2": "Group2MappedRole"
+    },
+    "groups": [
+        "special"
+    ]
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -6,16 +6,22 @@ mp.jwt.verify.issuer=https://quarkus.io/using-jwt-rbac
 quarkus.smallrye-jwt.enabled=true
 
 # define auth roles
-quarkus.http.auth.policy.role-reader.roles-allowed=reader,admin
-quarkus.http.auth.policy.role-writer.roles-allowed=writer,admin
+# define auth roles
+quarkus.http.auth.policy.role-reader.roles-allowed=reader,writer
+quarkus.http.auth.policy.role-writer.roles-allowed=writer
 
 # set the /config endpoint(s) to reader or admin role
 quarkus.http.auth.permission.read.paths=/config
 quarkus.http.auth.permission.read.policy=role-reader
 
-# set the /engagements endpoint(s) to writer or admin role
-quarkus.http.auth.permission.writer.paths=/engagements
+# set the /engagements/* endpoint(s) to writer for PUT and POST methods
+quarkus.http.auth.permission.writer.paths=/engagements/*
 quarkus.http.auth.permission.writer.policy=role-writer
+quarkus.http.auth.permission.writer.methods=PUT,POST
+
+# set the /engagements/* endpoint(s) to reader for other methods
+quarkus.http.auth.permission.reader.paths=/engagements/*
+quarkus.http.auth.permission.reader.policy=role-reader
 
 # mongo
 quarkus.mongodb.connection-string = mongodb://localhost:12345

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -28,8 +28,8 @@ quarkus.mongodb.connection-string = mongodb://localhost:12345
 quarkus.mongodb.database = engagement
 quarkus.mongodb.write-concern.journal=false
 
-# for test only run at 12am
-auto.save.cron.expr=0 0 0 * * ?
+# effectively disable
+auto.save.cron.expr=0 0 0 1 1 ? 2200
 
 git.commit=abcdef
 git.tag=77.8

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -29,7 +29,7 @@ quarkus.mongodb.database = engagement
 quarkus.mongodb.write-concern.journal=false
 
 # effectively disable
-auto.save.cron.expr=0 0 0 1 1 ? 2200
+auto.save.cron.expr=0 0 0 1 1 ? 2098
 
 git.commit=abcdef
 git.tag=77.8

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -28,7 +28,8 @@ quarkus.mongodb.connection-string = mongodb://localhost:12345
 quarkus.mongodb.database = engagement
 quarkus.mongodb.write-concern.journal=false
 
-auto.save.cron.expr=* * 0 * * ?
+# for test only run at 12am
+auto.save.cron.expr=0 0 0 * * ?
 
 git.commit=abcdef
 git.tag=77.8


### PR DESCRIPTION
- use reader and writer roles to secure endpoints for backend
- reader and writer can access the GET methods for `/config` and `/engagements/*`
- writer can access POST and PUT methods for `/engagements/*`