### PR TITLE
Embedded Mongo Test Extension

### DIFF
--- a/src/test/java/com/redhat/labs/omp/config/VersionManifestConfigTest.java
+++ b/src/test/java/com/redhat/labs/omp/config/VersionManifestConfigTest.java
@@ -7,9 +7,11 @@ import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.redhat.labs.omp.model.VersionManifest;
+import com.redhat.labs.utils.EmbeddedMongoTest;
 
 import io.quarkus.test.junit.QuarkusTest;
 
+@EmbeddedMongoTest
 @QuarkusTest
 public class VersionManifestConfigTest {
 

--- a/src/test/java/com/redhat/labs/omp/resources/ConfigResourceTest.java
+++ b/src/test/java/com/redhat/labs/omp/resources/ConfigResourceTest.java
@@ -8,10 +8,12 @@ import java.util.HashMap;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.Test;
 
+import com.redhat.labs.utils.EmbeddedMongoTest;
 import com.redhat.labs.utils.TokenUtils;
 
 import io.quarkus.test.junit.QuarkusTest;
 
+@EmbeddedMongoTest
 @QuarkusTest
 public class ConfigResourceTest {
 

--- a/src/test/java/com/redhat/labs/omp/resources/EngagementResourceTest.java
+++ b/src/test/java/com/redhat/labs/omp/resources/EngagementResourceTest.java
@@ -2,8 +2,8 @@ package com.redhat.labs.omp.resources;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.HashMap;
@@ -11,73 +11,23 @@ import java.util.HashMap;
 import javax.inject.Inject;
 import javax.json.bind.Jsonb;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.redhat.labs.omp.model.Engagement;
 import com.redhat.labs.omp.rest.client.MockOMPGitLabAPIService.SCENARIO;
+import com.redhat.labs.utils.EmbeddedMongoTest;
 import com.redhat.labs.utils.TokenUtils;
 
-import de.flapdoodle.embed.mongo.Command;
-import de.flapdoodle.embed.mongo.MongodExecutable;
-import de.flapdoodle.embed.mongo.MongodProcess;
-import de.flapdoodle.embed.mongo.MongodStarter;
-import de.flapdoodle.embed.mongo.config.IMongodConfig;
-import de.flapdoodle.embed.mongo.config.MongodConfigBuilder;
-import de.flapdoodle.embed.mongo.config.Net;
-import de.flapdoodle.embed.mongo.config.RuntimeConfigBuilder;
-import de.flapdoodle.embed.mongo.distribution.Version;
-import de.flapdoodle.embed.process.config.IRuntimeConfig;
-import de.flapdoodle.embed.process.config.io.ProcessOutput;
-import de.flapdoodle.embed.process.runtime.Network;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 
+@EmbeddedMongoTest
 @QuarkusTest
 public class EngagementResourceTest {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(EngagementResourceTest.class);
-
-    private static final IRuntimeConfig config =
-            new RuntimeConfigBuilder()
-                .defaultsWithLogger(Command.MongoD, LOGGER)
-                .processOutput(ProcessOutput.getDefaultInstanceSilent())
-                .build();
-    private static final MongodStarter starter = MongodStarter.getInstance(config);
-
     @Inject
     Jsonb quarkusJsonb;
-
-    private MongodExecutable _mongodExe;
-    private MongodProcess _mongod;
-
-    @BeforeEach
-    protected void setUp() throws Exception {
-
-        // setup local config
-        IMongodConfig config = new MongodConfigBuilder()
-                .version(Version.Main.PRODUCTION)
-                .net(new Net("localhost", 12345, Network.localhostIsIPv6()))
-                .build();
-
-        // create executable
-        _mongodExe = starter.prepare(config);
-        // start mongo
-        _mongod = _mongodExe.start();
-
-    }
-
-    @AfterEach
-    protected void tearDown() throws Exception {
-
-        _mongod.stop();
-        _mongodExe.stop();
-
-    }
 
     /*
      * POST SCENARIOS:

--- a/src/test/java/com/redhat/labs/omp/resources/GitSyncResourceTest.java
+++ b/src/test/java/com/redhat/labs/omp/resources/GitSyncResourceTest.java
@@ -10,73 +10,23 @@ import java.util.HashMap;
 import javax.inject.Inject;
 import javax.json.bind.Jsonb;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.redhat.labs.omp.model.Engagement;
 import com.redhat.labs.omp.rest.client.MockOMPGitLabAPIService.SCENARIO;
+import com.redhat.labs.utils.EmbeddedMongoTest;
 import com.redhat.labs.utils.TokenUtils;
 
-import de.flapdoodle.embed.mongo.Command;
-import de.flapdoodle.embed.mongo.MongodExecutable;
-import de.flapdoodle.embed.mongo.MongodProcess;
-import de.flapdoodle.embed.mongo.MongodStarter;
-import de.flapdoodle.embed.mongo.config.IMongodConfig;
-import de.flapdoodle.embed.mongo.config.MongodConfigBuilder;
-import de.flapdoodle.embed.mongo.config.Net;
-import de.flapdoodle.embed.mongo.config.RuntimeConfigBuilder;
-import de.flapdoodle.embed.mongo.distribution.Version;
-import de.flapdoodle.embed.process.config.IRuntimeConfig;
-import de.flapdoodle.embed.process.config.io.ProcessOutput;
-import de.flapdoodle.embed.process.runtime.Network;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 
+@EmbeddedMongoTest
 @QuarkusTest
 public class GitSyncResourceTest {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(GitSyncResourceTest.class);
-
-    private static final IRuntimeConfig config =
-            new RuntimeConfigBuilder()
-                .defaultsWithLogger(Command.MongoD, LOGGER)
-                .processOutput(ProcessOutput.getDefaultInstanceSilent())
-                .build();
-    private static final MongodStarter starter = MongodStarter.getInstance(config);
-
     @Inject
     Jsonb quarkusJsonb;
-
-    private MongodExecutable _mongodExe;
-    private MongodProcess _mongod;
-
-    @BeforeEach
-    protected void setUp() throws Exception {
-
-        // setup local config
-        IMongodConfig config = new MongodConfigBuilder()
-                .version(Version.Main.PRODUCTION)
-                .net(new Net("localhost", 12345, Network.localhostIsIPv6()))
-                .build();
-
-        // create executable
-        _mongodExe = starter.prepare(config);
-        // start mongo
-        _mongod = _mongodExe.start();
-
-    }
-
-    @AfterEach
-    protected void tearDown() throws Exception {
-
-        _mongod.stop();
-        _mongodExe.stop();
-
-    }
 
     /*
      * Process Modified

--- a/src/test/java/com/redhat/labs/omp/resources/VersionResourceTest.java
+++ b/src/test/java/com/redhat/labs/omp/resources/VersionResourceTest.java
@@ -5,9 +5,12 @@ import static org.hamcrest.CoreMatchers.hasItem;
 
 import org.junit.jupiter.api.Test;
 
+import com.redhat.labs.utils.EmbeddedMongoTest;
+
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 
+@EmbeddedMongoTest
 @QuarkusTest
 public class VersionResourceTest {
 

--- a/src/test/java/com/redhat/labs/utils/EmbeddedMongoTest.java
+++ b/src/test/java/com/redhat/labs/utils/EmbeddedMongoTest.java
@@ -1,0 +1,15 @@
+package com.redhat.labs.utils;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(EmbeddedMongoTestExtension.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface EmbeddedMongoTest {
+
+}

--- a/src/test/java/com/redhat/labs/utils/EmbeddedMongoTestExtension.java
+++ b/src/test/java/com/redhat/labs/utils/EmbeddedMongoTestExtension.java
@@ -1,0 +1,122 @@
+package com.redhat.labs.utils;
+
+import java.io.IOException;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoDatabase;
+
+import de.flapdoodle.embed.mongo.MongodExecutable;
+import de.flapdoodle.embed.mongo.MongodProcess;
+import de.flapdoodle.embed.mongo.MongodStarter;
+import de.flapdoodle.embed.mongo.config.IMongodConfig;
+import de.flapdoodle.embed.mongo.config.MongodConfigBuilder;
+import de.flapdoodle.embed.mongo.config.Net;
+import de.flapdoodle.embed.mongo.distribution.Version;
+import de.flapdoodle.embed.process.exceptions.DistributionException;
+import de.flapdoodle.embed.process.runtime.Network;
+
+public class EmbeddedMongoTestExtension implements BeforeAllCallback, AfterAllCallback, BeforeEachCallback{
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EmbeddedMongoTestExtension.class);
+
+    private final List<String> defaultDatabaseNames = new ArrayList<>(Arrays.asList("admin", "config", "local"));
+
+    private static final MongodStarter starter = MongodStarter.getDefaultInstance();
+
+    private MongodExecutable mongodExe;
+    private MongodProcess mongod;
+
+    private MongoClient mongoClient;
+    private int port = 12345;
+
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
+
+        for(String dbName : mongoClient.listDatabaseNames()) {
+
+            // skip any of the default mongo dbs
+            if(defaultDatabaseNames.contains(dbName)) {
+                continue;
+            }
+
+            LOGGER.debug("dropping collections for database: {}", dbName);
+
+            // get database
+            MongoDatabase db = mongoClient.getDatabase(dbName);
+
+            // drop each collection from db
+            for (String collectionName : db.listCollectionNames()) {
+                LOGGER.debug("...dropping collection {}", collectionName);
+                db.getCollection(collectionName).drop();
+            }
+
+        }
+
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) throws Exception {
+
+        LOGGER.debug("stopping mongo...");
+        // stop mongo
+        stopMongod();
+
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+
+        LOGGER.debug("starting mongo...");
+        // start mongo
+        startMongod();
+
+        LOGGER.debug("creating mongo client...");
+        createMongoClient();
+
+    }
+
+    private void createMongoClient() {
+
+        if (null == mongoClient) {
+            mongoClient = MongoClients.create("mongodb://localhost:12345");
+        }
+
+    }
+
+    private IMongodConfig createMongodConfig() throws UnknownHostException, IOException {
+        return new MongodConfigBuilder().version(Version.Main.PRODUCTION).net(new Net(port, Network.localhostIsIPv6()))
+                .build();
+    }
+
+    private void startMongod() throws DistributionException, UnknownHostException, IOException {
+
+        mongodExe = starter.prepare(createMongodConfig());
+        mongod = mongodExe.start();
+
+    }
+
+    private void stopMongod() {
+
+        if (null != mongod) {
+            mongod.stop();
+        }
+
+        if (null != mongodExe) {
+            mongodExe.stop();
+        }
+
+    }
+
+}


### PR DESCRIPTION
The tests that require a running Mongo need to make sure the instance is running before the Quarkus app is started. 

- Existing Tests now use the @EmbeddedMongoTest annotation
- The EmbeddedTestExtension is a Junit 5 Test extension that will manage the embedded Mongo instance.  It will start Mongo before running the tests, clear any data in databases (except for admin, local, and config) before each test, and then stop Mongo after the tests
- @EmbeddedMongoTest is used before the @QuarkusTest extension to insure the correct startup order
- Tests run faster because Mongo is only started and stopped once per test class using the extension

This change is required to make the update to the Backend API where it will load the Mongo DB on startup if it doesn't already have data.  Without it, the application won't start because Mongo is not yet available when this process runs.