### PR TITLE
Bug Fix for Becoming Active as Result of Prior Active Stale/Missing

### DIFF
--- a/src/main/java/com/redhat/labs/omp/resource/GitSyncResource.java
+++ b/src/main/java/com/redhat/labs/omp/resource/GitSyncResource.java
@@ -2,8 +2,6 @@ package com.redhat.labs.omp.resource;
 
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
-import javax.json.Json;
-import javax.json.JsonObject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -56,21 +54,6 @@ public class GitSyncResource {
 
         service.processModifiedEngagements();
         return Response.ok().build();
-
-    }
-
-    @PUT
-    @Path("/autosave/toggle")
-    @SecurityRequirement(name = "jwt", scopes = {})
-    @APIResponses(value = {
-            @APIResponse(responseCode = "401", description = "Missing or Invalid JWT"),
-            @APIResponse(responseCode = "200", description = "The autosave feature has been toggled on or off.")})
-    @Operation(summary = "Starts or stops the autosave feature, depending on the current state.")
-    public Response toggle() {
-
-        boolean value = service.toggleAutoSave();
-        JsonObject model = Json.createObjectBuilder().add("autosave", value).build();
-        return Response.ok().entity(model).build();
 
     }
 

--- a/src/main/java/com/redhat/labs/omp/service/ActiveGitSyncService.java
+++ b/src/main/java/com/redhat/labs/omp/service/ActiveGitSyncService.java
@@ -1,0 +1,131 @@
+package com.redhat.labs.omp.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.redhat.labs.omp.model.ActiveSync;
+import com.redhat.labs.omp.repository.ActiveSyncRepository;
+
+import io.quarkus.panache.common.Sort;
+import io.quarkus.runtime.StartupEvent;
+import io.quarkus.scheduler.Scheduled;
+
+public class ActiveGitSyncService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ActiveGitSyncService.class);
+
+    @Inject
+    ActiveSyncRepository activeSyncRepository;
+
+    @Inject
+    GitSyncService gitSyncService;
+
+    private final UUID uuid = UUID.randomUUID();
+
+    private boolean active = false;
+
+    /**
+     * Check to see if application should take the active role for sync processes.
+     * Then, requests that the database be refreshed if it does not contain data
+     * already.
+     * 
+     * @param event
+     */
+    void onStart(@Observes StartupEvent event) {
+
+        LOGGER.debug("starting instance {}", uuid);
+        // try to set active flag
+        checkIfActive();
+
+    }
+
+    /**
+     * Sets the active status to true if this application instance is performing the
+     * sync processing. Will make itself active if the record goes stale in the db.
+     * Otherwise, will set the active status to false which indicates it should not
+     * be processing.
+     * 
+     * @return
+     */
+    @Scheduled(every = "10s")
+    void checkIfActive() {
+
+        // get record from db
+        List<ActiveSync> syncRecordList = activeSyncRepository.listAll(Sort.ascending("lastUpdated"));
+
+        if (syncRecordList.size() == 0) {
+
+            LOGGER.debug("no active found, inserting active record for instance {}", uuid);
+
+            // try to insert the record to become the active instance
+            activeSyncRepository.persist(new ActiveSync(uuid, LocalDateTime.now()));
+            active = true;
+            return;
+
+        }
+
+        // get control record
+        ActiveSync sync = syncRecordList.remove(0);
+
+        // if i created the record, update the time stamp
+        if (uuid.equals(sync.getUuid())) {
+
+            LOGGER.debug("i {} am active, updating check in timestamp.", uuid);
+            // i am active, update time stamp
+            sync.setLastUpdated(LocalDateTime.now());
+            activeSyncRepository.update(sync);
+            active = true;
+
+            // shouldn't happen, but remove extra records if more than one exists
+            if (syncRecordList.size() > 0) {
+
+                LOGGER.debug("found multiple control records, performing cleanup");
+                for (ActiveSync record : syncRecordList) {
+                    activeSyncRepository.delete(record);
+                }
+
+            }
+
+            return;
+
+        }
+
+        // i didn't create it, but check if last updated is stale
+        if (sync.getLastUpdated().isBefore(LocalDateTime.now().minusSeconds(15))) {
+
+            LOGGER.debug("timestamp exceeded, i {} am becoming active.", uuid);
+            sync.setUuid(uuid);
+            sync.setLastUpdated(LocalDateTime.now());
+            activeSyncRepository.persistOrUpdate(sync);
+            active = true;
+            return;
+
+        }
+
+        LOGGER.debug("i {} am not active.", uuid);
+        active = false;
+
+    }
+
+    /**
+     * Triggers push of modified engagements at scheduled timeframe to indicate all
+     * modifications in the database should be pushed to Git.
+     */
+    @Scheduled(cron = "{auto.save.cron.expr}")
+    void pushModififedEngagementsToGit() {
+
+        if (active) {
+            LOGGER.debug("scheduled job for send process time elapsed event triggered. {}", active);
+            gitSyncService.processModifiedEngagements();
+        }
+
+    }
+
+}

--- a/src/main/java/com/redhat/labs/omp/service/GitSyncService.java
+++ b/src/main/java/com/redhat/labs/omp/service/GitSyncService.java
@@ -1,9 +1,6 @@
 package com.redhat.labs.omp.service;
 
-import java.time.LocalDateTime;
 import java.util.List;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -14,22 +11,15 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.redhat.labs.omp.model.ActiveSync;
 import com.redhat.labs.omp.model.Engagement;
 import com.redhat.labs.omp.model.FileAction;
 import com.redhat.labs.omp.repository.ActiveSyncRepository;
 import com.redhat.labs.omp.rest.client.OMPGitLabAPIService;
 
-import io.quarkus.panache.common.Sort;
-import io.quarkus.scheduler.Scheduled;
-
 @ApplicationScoped
 public class GitSyncService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GitSyncService.class);
-    private final UUID uuid = UUID.randomUUID();
-
-    AtomicBoolean autosave = new AtomicBoolean(true);
 
     @Inject
     ActiveSyncRepository activeSyncRepository;
@@ -40,36 +30,6 @@ public class GitSyncService {
     @Inject
     @RestClient
     OMPGitLabAPIService gitApiClient;
-
-    /**
-     * Periodically processes modified {@link Engagement} in the data store by
-     * calling the Git API to update Git.
-     */
-    @Scheduled(cron = "{auto.save.cron.expr}")
-    void sendChangesToGitApi() {
-
-        if (autosave.get() && active()) {
-
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("backend instance {} is active and performing push to git.", uuid);
-            }
-
-            processModifiedEngagements();
-
-        }
-
-    }
-
-    public boolean toggleAutoSave() {
-
-        boolean temp;
-        do {
-            temp = autosave.get();
-        } while (!autosave.compareAndSet(temp, !temp));
-
-        return autosave.get();
-
-    }
 
     public void refreshBackedFromGit() {
 
@@ -82,61 +42,6 @@ public class GitSyncService {
         engagementService.syncWithGitLab(engagementList);
 
         LOGGER.info("refresh of backend data complete.");
-
-    }
-
-    /**
-     * Return true if this application instance is performing the sync processing.
-     * Will make itself active if the record goes stale in the db. Otherwise, will
-     * return false to indicate it should not be processing.
-     * 
-     * @return
-     */
-    boolean active() {
-
-        // get record from db
-        List<ActiveSync> syncRecordList = activeSyncRepository.listAll(Sort.ascending("lastUpdated"));
-
-        if (syncRecordList.size() == 0) {
-
-            // try to insert the record to become the active instance
-            activeSyncRepository.persist(new ActiveSync(uuid, LocalDateTime.now()));
-            return true;
-
-        }
-
-        // get control record
-        ActiveSync sync = syncRecordList.remove(0);
-
-        // shouldn't happen, but remove extra records if more than one exists
-        if (syncRecordList.size() > 0) {
-
-            for (ActiveSync record : syncRecordList) {
-                activeSyncRepository.delete(record);
-            }
-
-        }
-
-        // if i created the record, update the time stamp
-        if (uuid.equals(sync.getUuid())) {
-
-            // i am active, update time stamp
-            sync.setLastUpdated(LocalDateTime.now());
-            activeSyncRepository.update(sync);
-            return true;
-
-        }
-
-        // i didn't create it, but check if last updated is stale
-        if (sync.getLastUpdated().isBefore(LocalDateTime.now().minusMinutes(1))) {
-
-            sync.setUuid(uuid);
-            activeSyncRepository.persistOrUpdate(sync);
-            return true;
-
-        }
-
-        return false;
 
     }
 


### PR DESCRIPTION
- fix for checkIfActive not setting timestamp when new instance becoming active
- separated active sync logic and sync logic
    - ActiveGitSyncService responsible for managing active state and triggering scheduled pushes to git
    - GitSyncService responsible for interactions between EngagementService and Git API
- removed auto save toggle (did not work for multiple instances)