### PR TITLE
Database Population on Application Startup

### DIFF
--- a/src/main/java/com/redhat/labs/omp/model/event/BackendEvent.java
+++ b/src/main/java/com/redhat/labs/omp/model/event/BackendEvent.java
@@ -1,0 +1,42 @@
+package com.redhat.labs.omp.model.event;
+
+import java.util.List;
+
+import com.redhat.labs.omp.model.Engagement;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class BackendEvent {
+
+    private EventType eventType;
+    private List<Engagement> engagementList;
+    @Builder.Default
+    private boolean forceUpdate = false;
+
+    public static BackendEvent createDatabaseRefreshRequestedEvent(boolean forceUpdate) {
+        return BackendEvent.builder().eventType(EventType.DB_REFRESH_REQUESTED).forceUpdate(forceUpdate).build();
+    }
+
+    public static BackendEvent createDatabaseRefreshEvent(List<Engagement> engagmentList, boolean forceUpdate) {
+        return BackendEvent.builder().eventType(EventType.DB_REFRESH).engagementList(engagmentList)
+                .forceUpdate(forceUpdate).build();
+    }
+
+    public static BackendEvent createPushToGitRequestedEvent() {
+        return BackendEvent.builder().eventType(EventType.PUSH_TO_GIT_REQUESTED).build();
+    }
+
+    public static BackendEvent createUpdateEngagementsInDbRequestedEvent(List<Engagement> engagementList) {
+        return BackendEvent.builder().eventType(EventType.UPDATE_ENGAGEMENTS_IN_DB_REQUESTED)
+                .engagementList(engagementList).build();
+    }
+
+    public static BackendEvent createUpdateEngagementsInGitRequestedEvent(List<Engagement> engagementList) {
+        return BackendEvent.builder().eventType(EventType.UPDATE_ENGAGEMENTS_IN_GIT_REQUESTED)
+                .engagementList(engagementList).build();
+    }
+
+}

--- a/src/main/java/com/redhat/labs/omp/model/event/EventType.java
+++ b/src/main/java/com/redhat/labs/omp/model/event/EventType.java
@@ -1,0 +1,31 @@
+package com.redhat.labs.omp.model.event;
+
+public enum EventType {
+
+    DB_REFRESH_REQUESTED(Constants.DB_REFRESH_REQUESTED_ADDRESS), 
+    DB_REFRESH(Constants.DB_REFRESH_ADDRESS),
+    PUSH_TO_GIT_REQUESTED(Constants.PUSH_TO_GIT_REQUESTED_ADDRESS),
+    UPDATE_ENGAGEMENTS_IN_DB_REQUESTED(Constants.UPDATE_ENGAGEMENTS_IN_DB_REQUESTED_ADDRESS),
+    UPDATE_ENGAGEMENTS_IN_GIT_REQUESTED(Constants.UPDATE_ENGAGEMENTS_IN_GIT_REQUESTED_ADDRESS);
+
+    private String eventBusAddress;
+
+    EventType(String eventBusAddress) {
+        this.eventBusAddress = eventBusAddress;
+    }
+
+    public String getEventBusAddress() {
+        return this.eventBusAddress;
+    }
+
+    public class Constants {
+
+        public static final String DB_REFRESH_REQUESTED_ADDRESS = "db.refresh.requested.event";
+        public static final String DB_REFRESH_ADDRESS = "db.refresh.event";
+        public static final String PUSH_TO_GIT_REQUESTED_ADDRESS = "push.to.git.requested.event";
+        public static final String UPDATE_ENGAGEMENTS_IN_DB_REQUESTED_ADDRESS = "update.engagements.in.db.requested.event";
+        public static final String UPDATE_ENGAGEMENTS_IN_GIT_REQUESTED_ADDRESS = "update.engagements.in.git.requested.event";
+
+    }
+
+} 


### PR DESCRIPTION
- added refresh mongo database to app start up if instance is active and no engagements exist in the db
- simplified communication using events and event bus
    - ActiveGitSyncService, GitSyncService, and EngagementService only communicate through the Event Bus using Events
- method visibility and general cleanup