### PR TITLE
Validate Customer and Project Name

### DIFF
--- a/src/main/java/com/redhat/labs/omp/model/Engagement.java
+++ b/src/main/java/com/redhat/labs/omp/model/Engagement.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import javax.json.bind.annotation.JsonbProperty;
 import javax.json.bind.annotation.JsonbTransient;
-import javax.validation.constraints.NotBlank;
 
 import org.bson.codecs.pojo.annotations.BsonId;
 import org.bson.types.ObjectId;
@@ -29,12 +28,9 @@ public class Engagement extends PanacheMongoEntityBase {
     @BsonId
     @JsonbProperty("mongo_id")
     private ObjectId mongoId;
-
-    @NotBlank
     @ValidName
     @JsonbProperty("customer_name")
     private String customerName;
-    @NotBlank
     @ValidName
     @JsonbProperty("project_name")
     private String projectName;

--- a/src/main/java/com/redhat/labs/omp/model/Engagement.java
+++ b/src/main/java/com/redhat/labs/omp/model/Engagement.java
@@ -9,6 +9,8 @@ import javax.validation.constraints.NotBlank;
 import org.bson.codecs.pojo.annotations.BsonId;
 import org.bson.types.ObjectId;
 
+import com.redhat.labs.omp.validation.ValidName;
+
 import io.quarkus.mongodb.panache.PanacheMongoEntityBase;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -29,9 +31,11 @@ public class Engagement extends PanacheMongoEntityBase {
     private ObjectId mongoId;
 
     @NotBlank
+    @ValidName
     @JsonbProperty("customer_name")
     private String customerName;
     @NotBlank
+    @ValidName
     @JsonbProperty("project_name")
     private String projectName;
     @JsonbProperty("project_id")

--- a/src/main/java/com/redhat/labs/omp/validation/NameValidator.java
+++ b/src/main/java/com/redhat/labs/omp/validation/NameValidator.java
@@ -1,0 +1,29 @@
+package com.redhat.labs.omp.validation;
+
+import java.util.regex.Pattern;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@ApplicationScoped
+public class NameValidator implements ConstraintValidator<ValidName, String> {
+
+    // Defaults to GitLab Group Name Pattern:
+    // GitLab currently has the following restrictions on group names:
+    // Names can contain only letters, digits, emojis, '_', '.', dash, space,
+    // parenthesis. It must start with letter, digit, emoji or '_'.
+    @ConfigProperty(name = "valid.name.regex", defaultValue = "^(\\p{L}|\\p{N}|_)[\\p{L}\\p{N}\\p{Z}-_\\.\\(\\)]*$")
+    String validNameRegex;
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+
+        Pattern pattern = Pattern.compile(validNameRegex, Pattern.UNICODE_CHARACTER_CLASS);
+        return pattern.matcher(value).matches();
+
+    }
+
+}

--- a/src/main/java/com/redhat/labs/omp/validation/NameValidator.java
+++ b/src/main/java/com/redhat/labs/omp/validation/NameValidator.java
@@ -21,6 +21,10 @@ public class NameValidator implements ConstraintValidator<ValidName, String> {
     @Override
     public boolean isValid(String value, ConstraintValidatorContext context) {
 
+        if(null == value || value.trim().length() == 0) {
+            return false;
+        }
+
         Pattern pattern = Pattern.compile(validNameRegex, Pattern.UNICODE_CHARACTER_CLASS);
         return pattern.matcher(value).matches();
 

--- a/src/main/java/com/redhat/labs/omp/validation/ValidName.java
+++ b/src/main/java/com/redhat/labs/omp/validation/ValidName.java
@@ -1,0 +1,46 @@
+package com.redhat.labs.omp.validation;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+import com.redhat.labs.omp.validation.ValidName.List;
+
+@Documented
+@Constraint(validatedBy = { NameValidator.class })
+@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
+@Retention(RUNTIME)
+@Repeatable(List.class)
+public @interface ValidName {
+
+    String message() default "Can contain only letters, digits, '_', '.', '-', space, and parenthesis. It must start with letter, digit, or '_'.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    /**
+     * Defines several {@code ValidName} constraints on the same element.
+     *
+     * @see ValidName
+     */
+    @Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
+    @Retention(RUNTIME)
+    @Documented
+    public @interface List {
+        ValidName[] value();
+    }
+
+}

--- a/src/test/java/com/redhat/labs/omp/validation/NameValidatorTest.java
+++ b/src/test/java/com/redhat/labs/omp/validation/NameValidatorTest.java
@@ -1,0 +1,108 @@
+package com.redhat.labs.omp.validation;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.wildfly.common.Assert;
+
+import com.redhat.labs.utils.EmbeddedMongoTest;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@EmbeddedMongoTest
+@QuarkusTest
+public class NameValidatorTest {
+
+    @Inject
+    NameValidator validator;
+
+    @Test
+    public void testStartsWithLetter() {
+
+        String input = "Diw34 Id (d)._";
+        Assert.assertTrue(validator.isValid(input, null));
+
+    }
+
+    @Test
+    public void testStartsWithLetterAnyLanguage() {
+
+        String input = "øDiw34 Id (d)._";
+        Assert.assertTrue(validator.isValid(input, null));
+
+    }
+
+    @Test
+    public void testStartsWithDigit() {
+
+        String input = "23øDiw34 Id (d)._";
+        Assert.assertTrue(validator.isValid(input, null));
+
+    }
+
+    @Test
+    public void testStartsWithUnderscore() {
+
+        String input = "_Diw34 Id (d)._";
+        Assert.assertTrue(validator.isValid(input, null));
+
+    }
+
+    @Test
+    public void testStartsWithLeftParenthesis() {
+
+        String input = "(Diw34 Id (d)._";
+        Assert.assertFalse(validator.isValid(input, null));
+
+    }
+
+    @Test
+    public void testStartsWithRightParenthesis() {
+
+        String input = ")Diw34 Id (d)._";
+        Assert.assertFalse(validator.isValid(input, null));
+
+    }
+
+    @Test
+    public void testStartsWithPeriod() {
+
+        String input = ".Diw34 Id (d)._";
+        Assert.assertFalse(validator.isValid(input, null));
+
+    }
+
+    @Test
+    public void testStartsWithSpace() {
+
+        String input = " Diw34 Id (d)._";
+        Assert.assertFalse(validator.isValid(input, null));
+
+    }
+
+    @Test
+    public void testStartsWithHyphen() {
+
+        String input = "-Diw34 Id (d)._";
+        Assert.assertFalse(validator.isValid(input, null));
+
+    }
+
+    // letters, digits, emojis, '_', '.', dash, space, parenthesis
+    @Test
+    public void testAllValidCharacters() {
+
+        String input = "aDi†¥øw34 Id (d)._";
+        Assert.assertFalse(validator.isValid(input, null));
+
+    }
+
+    @Test
+    public void testAllInValidCharactersExclaimation() {
+
+        String input = "aDi†¥øw!34 Id (d)._";
+        Assert.assertFalse(validator.isValid(input, null));
+
+    }
+
+}

--- a/src/test/java/com/redhat/labs/omp/validation/NameValidatorTest.java
+++ b/src/test/java/com/redhat/labs/omp/validation/NameValidatorTest.java
@@ -17,6 +17,29 @@ public class NameValidatorTest {
     NameValidator validator;
 
     @Test
+    public void testValueIsNull() {
+
+        Assert.assertFalse(validator.isValid(null, null));
+
+    }
+
+    @Test
+    public void testValueIsEmptyString() {
+
+        String input = "";
+        Assert.assertFalse(validator.isValid(input, null));
+
+    }
+
+    @Test
+    public void testValueIsWhitespace() {
+
+        String input = "   ";
+        Assert.assertFalse(validator.isValid(input, null));
+
+    }
+
+    @Test
     public void testStartsWithLetter() {
 
         String input = "Diw34 Id (d)._";


### PR DESCRIPTION
- conforming to the current GitLab requirements for group names
    - Name can contain only letters, digits, emojis, '_', '.', dash, space, parenthesis. It must start with letter, digit, emoji or '_'.
- did not implement the emojis
- regex is configurable using property `valid.name.regex` or environment variable `VALID_NAME_REGEX`