### PR TITLE
 Have Helm chart create initial route

### DIFF
--- a/deployment/Chart.yaml
+++ b/deployment/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: backend
 description: A Helm chart to deploy the backend (coordination API) of the Open Management Portal
 

--- a/deployment/templates/route.yaml
+++ b/deployment/templates/route.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.development }}
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
@@ -13,6 +12,7 @@ spec:
     targetPort: "{{ .Values.servicePort }}-tcp"
   tls:
     termination: edge
+    insecureEdgeTerminationPolicy: Redirect
   to:
     kind: Service
     name: {{ .Values.name }}
@@ -20,4 +20,3 @@ spec:
   wildcardPolicy: None
 status:
   ingress: []
-{{- end }}


### PR DESCRIPTION
Rather than having our runtime-config handle the creation of our route, this will now add the route creation to our helm chart. This also bumps the Helm chart to use Helm 3 