### PR TITLE
Event Loop Should not be Blocked By Longer Running Processes

### DIFF
--- a/src/test/java/com/redhat/labs/omp/resources/GitSyncResourceTest.java
+++ b/src/test/java/com/redhat/labs/omp/resources/GitSyncResourceTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 import javax.json.bind.Jsonb;
@@ -272,6 +273,9 @@ public class GitSyncResourceTest {
             .put("/engagements/refresh")
         .then()
             .statusCode(200);
+
+        // make sure the async processes finish
+        TimeUnit.SECONDS.sleep(1);
 
         // GET all engagement
         Response response = 


### PR DESCRIPTION
When events are being processed from the EventBus, warnings will be logged if the execution of the consumer takes longer than 2 seconds.  This is because the event loop is being blocked.  This fix moved the main 2 offenders into a separate execution thread by using Vertx.executeBlocking clauses.

- Processing a DbRefreshRequestedEvent
- Processing a UpdateEngagementsInGitRequestedEvent

Both of these are using the REST Git API which can cause a delayed response.